### PR TITLE
Hub, Company, Order, Delivey 도메인에 대해 스웨거 적용

### DIFF
--- a/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/infrastructure/config/SwaggerConfig.java
+++ b/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.sparta_logistics.company.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Components components = new Components()
+        .addSecuritySchemes("X-User-Id",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Id"))
+        .addSecuritySchemes("X-User-Name",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Name"))
+        .addSecuritySchemes("X-User-Role",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Role"));
+    return new OpenAPI()
+        .components(components)
+        .addSecurityItem(new SecurityRequirement()
+            .addList("X-User-Id")
+            .addList("X-User-Name")
+            .addList("X-User-Role"))
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("Spring Boot REST API Specifications")
+        .description("product api")
+        .version("1.0.0");
+  }
+
+}

--- a/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/config/SecurityConfig.java
+++ b/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/config/SecurityConfig.java
@@ -27,8 +27,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .anyRequest().permitAll()
         )
-        .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
-        .httpBasic(Customizer.withDefaults());
+        .httpBasic(Customizer.withDefaults())
+        .httpBasic(AbstractHttpConfigurer::disable);
 
     return http.build();
   }

--- a/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/filter/JwtAuthenticationFilter.java
+++ b/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/filter/JwtAuthenticationFilter.java
@@ -19,29 +19,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    //Mock 데이터 생성
 
-    String userId = request.getHeader("X-User-Id");
-    String userName = request.getHeader("X-User-Name");
-    String role = request.getHeader("X-User-Role");
+    if (request.getRequestURI().startsWith("/api/v1/companies/v3/api-docs") ||
+    request.getRequestURI().startsWith("/api/v1/companies/swagger")){
+      filterChain.doFilter(request, response);
+    } else {
+      //Mock 데이터 생성
+      String userId = request.getHeader("X-User-Id");
+      String userName = request.getHeader("X-User-Name");
+      String role = request.getHeader("X-User-Role");
 
-    if (userName == null || role == null) {
-      throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+      if (userName == null || role == null) {
+        throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+      }
+
+      //Mock 유저 생성
+      RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role);
+
+      // Authentication 객체 생성
+      UsernamePasswordAuthenticationToken authentication =
+          new UsernamePasswordAuthenticationToken(mockUserDetails, null,
+              mockUserDetails.getAuthorities());
+
+      // SecurityContext에 인증 정보 설정
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      // 필터 체인 진행
+      filterChain.doFilter(request, response);
     }
-
-    //Mock 유저 생성
-    RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role);
-
-    // Authentication 객체 생성
-    UsernamePasswordAuthenticationToken authentication =
-        new UsernamePasswordAuthenticationToken(mockUserDetails, null,
-            mockUserDetails.getAuthorities());
-
-    // SecurityContext에 인증 정보 설정
-    SecurityContextHolder.getContext().setAuthentication(authentication);
-
-    // 필터 체인 진행
-    filterChain.doFilter(request, response);
-
   }
 }

--- a/com.sparta_logistics.delivery/build.gradle
+++ b/com.sparta_logistics.delivery/build.gradle
@@ -28,6 +28,9 @@ ext {
 }
 
 dependencies {
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/config/SecurityConfig.java
+++ b/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .anyRequest().permitAll()
         )
-        .httpBasic(Customizer.withDefaults());
+        .httpBasic(Customizer.withDefaults())
+        .httpBasic(AbstractHttpConfigurer::disable);
 
     return http.build();
   }

--- a/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/config/SwaggerConfig.java
+++ b/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/config/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.sparta_logistics.delivery.presentation.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Components components = new Components()
+        .addSecuritySchemes("X-User-Id",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Id"))
+        .addSecuritySchemes("X-User-Name",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Name"))
+        .addSecuritySchemes("X-User-Role",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Role"));
+    return new OpenAPI()
+        .components(components)
+        .addSecurityItem(new SecurityRequirement()
+            .addList("X-User-Id")
+            .addList("X-User-Name")
+            .addList("X-User-Role"))
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("Spring Boot REST API Specifications")
+        .description("product api")
+        .version("1.0.0");
+  }
+
+}

--- a/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/filter/JwtAuthenticationFilter.java
+++ b/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/filter/JwtAuthenticationFilter.java
@@ -18,27 +18,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    //Mock 데이터 생성
-    String userId = request.getHeader("X-User-Id");
-    String userName = request.getHeader("X-User-Name");
-    String role = request.getHeader("X-User-Role");
 
-    if (userId == null || userName == null || role == null) {
-      throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+    if (request.getRequestURI().startsWith("/api/v1/deliveries/v3/api-docs") ||
+        request.getRequestURI().startsWith("/api/v1/deliveries/swagger")){
+      filterChain.doFilter(request, response);
+    } else {
+      //Mock 데이터 생성
+      String userId = request.getHeader("X-User-Id");
+      String userName = request.getHeader("X-User-Name");
+      String role = request.getHeader("X-User-Role");
+
+      if (userId == null || userName == null || role == null) {
+        throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+      }
+
+      //Mock 유저 생성
+      RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role);
+
+      // Authentication 객체 생성
+      UsernamePasswordAuthenticationToken authentication =
+          new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities());
+
+      // SecurityContext에 인증 정보 설정
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      // 필터 체인 진행
+      filterChain.doFilter(request, response);
     }
-
-    //Mock 유저 생성
-    RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role);
-
-    // Authentication 객체 생성
-    UsernamePasswordAuthenticationToken authentication =
-        new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities());
-
-    // SecurityContext에 인증 정보 설정
-    SecurityContextHolder.getContext().setAuthentication(authentication);
-
-    // 필터 체인 진행
-    filterChain.doFilter(request, response);
-
   }
 }

--- a/com.sparta_logistics.hub/build.gradle
+++ b/com.sparta_logistics.hub/build.gradle
@@ -29,6 +29,8 @@ ext {
 }
 
 dependencies {
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	//config-client
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/com.sparta_logistics.hub/src/main/java/com/sparta_logistics/hub/infrastructure/configuration/SwaggerConfig.java
+++ b/com.sparta_logistics.hub/src/main/java/com/sparta_logistics/hub/infrastructure/configuration/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.sparta_logistics.hub.infrastructure.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Components components = new Components()
+        .addSecuritySchemes("X-User-Id",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Id"))
+        .addSecuritySchemes("X-User-Name",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Name"))
+        .addSecuritySchemes("X-User-Role",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Role"));
+    return new OpenAPI()
+        .components(components)
+        .addSecurityItem(new SecurityRequirement()
+            .addList("X-User-Id")
+            .addList("X-User-Name")
+            .addList("X-User-Role"))
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("Spring Boot REST API Specifications")
+        .description("product api")
+        .version("1.0.0");
+  }
+
+}

--- a/com.sparta_logistics.order/build.gradle
+++ b/com.sparta_logistics.order/build.gradle
@@ -31,12 +31,12 @@ dependencies {
 	//config-client
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'

--- a/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/config/SecurityConfig.java
+++ b/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .anyRequest().permitAll()
         )
-        .httpBasic(Customizer.withDefaults());
+        .httpBasic(Customizer.withDefaults())
+        .httpBasic(AbstractHttpConfigurer::disable);
 
     return http.build();
   }

--- a/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/config/SwaggerConfig.java
+++ b/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/config/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.sparta_logistics.order.presentation.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Components components = new Components()
+        .addSecuritySchemes("X-User-Id",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Id"))
+        .addSecuritySchemes("X-User-Name",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Name"))
+        .addSecuritySchemes("X-User-Role",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Role"));
+    return new OpenAPI()
+        .components(components)
+        .addSecurityItem(new SecurityRequirement()
+            .addList("X-User-Id")
+            .addList("X-User-Name")
+            .addList("X-User-Role"))
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("Spring Boot REST API Specifications")
+        .description("product api")
+        .version("1.0.0");
+  }
+
+}

--- a/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/filter/JwtAuthenticationFilter.java
+++ b/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/filter/JwtAuthenticationFilter.java
@@ -19,27 +19,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    //Mock 데이터 생성
-    String userId = request.getHeader("ID_HEADER");
-    String userName = request.getHeader("NAME_HEADER");
-    String role = request.getHeader("ROLE_HEADER");
-    String userSlackId = request.getHeader("SLACK_ID_HEADER");
-    if (userId == null || userName == null || role == null) {
-      throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+
+    if (request.getRequestURI().startsWith("/api/v1/orders/v3/api-docs") ||
+        request.getRequestURI().startsWith("/api/v1/orders/swagger")){
+      filterChain.doFilter(request, response);
+    } else {
+      //Mock 데이터 생성
+      String userId = request.getHeader("ID_HEADER");
+      String userName = request.getHeader("NAME_HEADER");
+      String role = request.getHeader("ROLE_HEADER");
+      String userSlackId = request.getHeader("SLACK_ID_HEADER");
+      if (userId == null || userName == null || role == null) {
+        throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+      }
+
+      //Mock 유저 생성
+      RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role, userSlackId);
+
+      // Authentication 객체 생성
+      UsernamePasswordAuthenticationToken authentication =
+          new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities());
+
+      // SecurityContext에 인증 정보 설정
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      // 필터 체인 진행
+      filterChain.doFilter(request, response);
     }
-
-    //Mock 유저 생성
-    RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role, userSlackId);
-
-    // Authentication 객체 생성
-    UsernamePasswordAuthenticationToken authentication =
-        new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities());
-
-    // SecurityContext에 인증 정보 설정
-    SecurityContextHolder.getContext().setAuthentication(authentication);
-
-    // 필터 체인 진행
-    filterChain.doFilter(request, response);
-
   }
 }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- refactor//67/swagger -> refactor//67/config
### 이슈
- #67 
### Description
- Hub, Company, Order, Delivey 도메인에 스웨거 적용완료했습니다.
- http://localhost:{각 서비스 포트 번호}/api/v1/{도메인(복수)}/v3/api-docs 요청을 통해 각 서비스의 swagger ui를 확인할 수 있습니다.
- Hub port : 19094
- Company port : 19095
- Order port : 19096
- Delivery port : 19098

### To Reviewers
- 팀장님 방식대로 filter에 mock 객체를 생성하면 모든 요청의 authentication이 해당 객체의 것으로 변경되는 듯 해서, swagger 요청에 대해서만 필터를 통과시키는 식으로 구현해 봤습니다.