### PR TITLE
Hub, Company, Order, delivery 환경 설정 (Config Server, Swagger)

### DIFF
--- a/com.sparta_logistics.company/build.gradle
+++ b/com.sparta_logistics.company/build.gradle
@@ -29,10 +29,18 @@ ext {
 }
 
 dependencies {
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	//querydsl
 	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// config-client
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/infrastructure/config/SwaggerConfig.java
+++ b/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.sparta_logistics.company.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Components components = new Components()
+        .addSecuritySchemes("X-User-Id",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Id"))
+        .addSecuritySchemes("X-User-Name",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Name"))
+        .addSecuritySchemes("X-User-Role",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Role"));
+    return new OpenAPI()
+        .components(components)
+        .addSecurityItem(new SecurityRequirement()
+            .addList("X-User-Id")
+            .addList("X-User-Name")
+            .addList("X-User-Role"))
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("Spring Boot REST API Specifications")
+        .description("product api")
+        .version("1.0.0");
+  }
+
+}

--- a/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/config/SecurityConfig.java
+++ b/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/config/SecurityConfig.java
@@ -27,8 +27,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .anyRequest().permitAll()
         )
-        .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
-        .httpBasic(Customizer.withDefaults());
+        .httpBasic(Customizer.withDefaults())
+        .httpBasic(AbstractHttpConfigurer::disable);
 
     return http.build();
   }

--- a/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/controller/CompanyController.java
+++ b/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/controller/CompanyController.java
@@ -10,6 +10,7 @@ import com.sparta_logistics.company.presentation.request.CompanyUpdateRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RefreshScope
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/companies")

--- a/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/filter/JwtAuthenticationFilter.java
+++ b/com.sparta_logistics.company/src/main/java/com/sparta_logistics/company/presentation/filter/JwtAuthenticationFilter.java
@@ -19,29 +19,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    //Mock 데이터 생성
 
-    String userId = request.getHeader("X-User-Id");
-    String userName = request.getHeader("X-User-Name");
-    String role = request.getHeader("X-User-Role");
+    if (request.getRequestURI().startsWith("/api/v1/companies/v3/api-docs") ||
+    request.getRequestURI().startsWith("/api/v1/companies/swagger")){
+      filterChain.doFilter(request, response);
+    } else {
+      //Mock 데이터 생성
+      String userId = request.getHeader("X-User-Id");
+      String userName = request.getHeader("X-User-Name");
+      String role = request.getHeader("X-User-Role");
 
-    if (userName == null || role == null) {
-      throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+      if (userName == null || role == null) {
+        throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+      }
+
+      //Mock 유저 생성
+      RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role);
+
+      // Authentication 객체 생성
+      UsernamePasswordAuthenticationToken authentication =
+          new UsernamePasswordAuthenticationToken(mockUserDetails, null,
+              mockUserDetails.getAuthorities());
+
+      // SecurityContext에 인증 정보 설정
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      // 필터 체인 진행
+      filterChain.doFilter(request, response);
     }
-
-    //Mock 유저 생성
-    RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role);
-
-    // Authentication 객체 생성
-    UsernamePasswordAuthenticationToken authentication =
-        new UsernamePasswordAuthenticationToken(mockUserDetails, null,
-            mockUserDetails.getAuthorities());
-
-    // SecurityContext에 인증 정보 설정
-    SecurityContextHolder.getContext().setAuthentication(authentication);
-
-    // 필터 체인 진행
-    filterChain.doFilter(request, response);
-
   }
 }

--- a/com.sparta_logistics.config/src/main/resources/config-repo/auth-service-local.yml
+++ b/com.sparta_logistics.config/src/main/resources/config-repo/auth-service-local.yml
@@ -2,15 +2,12 @@ spring:
   application:
     name: auth-service
   datasource:
-    url: jdbc:postgresql://localhost:5432/sparta_logistics_auth
+    url: jdbc:postgresql://localhost:5432/msaPracDB
     username: postgres
-    password: sky2002369
+    password: 1234
     driver-class-name: org.postgresql.Driver
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
     show-sql: true
@@ -33,7 +30,12 @@ management:
   tracing:
     sampling:
       probability: 1.0
-
+  # http://localhost:{포트 번호}/actuator/refresh 사용을 위한 설정
+  # 코드 내 @RefreshScope 적용 필요
+  endpoints:
+    web:
+      exposure:
+        include: refresh
 service:
   jwt:
     access-expiration: 3600000

--- a/com.sparta_logistics.config/src/main/resources/config-repo/company-service-local.yml
+++ b/com.sparta_logistics.config/src/main/resources/config-repo/company-service-local.yml
@@ -2,17 +2,18 @@ spring:
   application:
     name: company-service
   datasource:
-    url: jdbc:postgresql://localhost:5432/sparta_logistics_company
+    url: jdbc:postgresql://localhost:5432/msaPracDB
     username: postgres
-    password: sky2002369
+    password: 1234
     driver-class-name: org.postgresql.Driver
   jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
     show-sql: true
+  sql:
+    init:
+      mode: always
 
 server:
   port: 19095
@@ -21,3 +22,23 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
+management:
+  zipkin:
+    tracing:
+      endpoint: "http://localhost:9411/api/v2/spans"
+  tracing:
+    sampling:
+      probability: 1.0
+  # http://localhost:{포트 번호}/actuator/refresh 사용을 위한 설정
+  # 코드 내 @RefreshScope 적용 필요
+  endpoints:
+    web:
+      exposure:
+        include: refresh
+
+springdoc:
+  api-docs:
+    path: /api/v1/companies/v3/api-docs
+  swagger-ui:
+    path: /api/v1/companies/swagger-ui.html

--- a/com.sparta_logistics.config/src/main/resources/config-repo/delivery-service-local.yml
+++ b/com.sparta_logistics.config/src/main/resources/config-repo/delivery-service-local.yml
@@ -2,17 +2,18 @@ spring:
   application:
     name: delivery-service
   datasource:
-    url: jdbc:postgresql://localhost:5432/sparta_logistics_delivery
+    url: jdbc:postgresql://localhost:5432/msaPracDB
     username: postgres
-    password: sky2002369
+    password: 1234
     driver-class-name: org.postgresql.Driver
   jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
     show-sql: true
+  sql:
+    init:
+      mode: always
 
 server:
   port: 19098
@@ -21,3 +22,22 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+management:
+  zipkin:
+    tracing:
+      endpoint: "http://localhost:9411/api/v2/spans"
+  tracing:
+    sampling:
+      probability: 1.0
+  # http://localhost:{포트 번호}/actuator/refresh 사용을 위한 설정
+  # 코드 내 @RefreshScope 적용 필요
+  endpoints:
+    web:
+      exposure:
+        include: refresh
+
+springdoc:
+  api-docs:
+    path: /api/v1/deliveries/v3/api-docs
+  swagger-ui:
+    path: /api/v1/deliveries/swagger-ui.html

--- a/com.sparta_logistics.config/src/main/resources/config-repo/hub-service-local.yml
+++ b/com.sparta_logistics.config/src/main/resources/config-repo/hub-service-local.yml
@@ -2,18 +2,18 @@ spring:
   application:
     name: hub-service
   datasource:
-    url: jdbc:postgresql://localhost:5432/sparta_logistics_hub
+    url: jdbc:postgresql://localhost:5432/msaPracDB
     username: postgres
-    password: sky2002369
+    password: 1234
     driver-class-name: org.postgresql.Driver
   jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
     show-sql: true
-
+  sql:
+    init:
+      mode: always
 server:
   port: 19094
 
@@ -21,8 +21,6 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
-
-
 management:
   zipkin:
     tracing:
@@ -30,3 +28,14 @@ management:
   tracing:
     sampling:
       probability: 1.0
+  # http://localhost:{포트 번호}/actuator/refresh 사용을 위한 설정
+  # 코드 내 @RefreshScope 적용 필요
+  endpoints:
+    web:
+      exposure:
+        include: refresh
+springdoc:
+  api-docs:
+    path: /api/v1/hubs/v3/api-docs
+  swagger-ui:
+    path: /api/v1/hubs/swagger-ui.html

--- a/com.sparta_logistics.config/src/main/resources/config-repo/order-service-local.yml
+++ b/com.sparta_logistics.config/src/main/resources/config-repo/order-service-local.yml
@@ -2,9 +2,9 @@ spring:
   application:
     name: order-service
   datasource:
-    url: jdbc:postgresql://localhost:5432/sparta_logistics_order
+    url: jdbc:postgresql://localhost:5432/msaPracDB
     username: postgres
-    password: sky2002369
+    password: 1234
     driver-class-name: org.postgresql.Driver
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
@@ -21,3 +21,21 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+management:
+  zipkin:
+    tracing:
+      endpoint: "http://localhost:9411/api/v2/spans"
+  tracing:
+    sampling:
+      probability: 1.0
+  # http://localhost:{포트 번호}/actuator/refresh 사용을 위한 설정
+  # 코드 내 @RefreshScope 적용 필요
+  endpoints:
+    web:
+      exposure:
+        include: refresh
+springdoc:
+  api-docs:
+    path: /api/v1/orders/v3/api-docs
+  swagger-ui:
+    path: /api/v1/orders/swagger-ui.html

--- a/com.sparta_logistics.delivery/build.gradle
+++ b/com.sparta_logistics.delivery/build.gradle
@@ -28,6 +28,9 @@ ext {
 }
 
 dependencies {
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/config/SecurityConfig.java
+++ b/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .anyRequest().permitAll()
         )
-        .httpBasic(Customizer.withDefaults());
+        .httpBasic(Customizer.withDefaults())
+        .httpBasic(AbstractHttpConfigurer::disable);
 
     return http.build();
   }

--- a/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/config/SwaggerConfig.java
+++ b/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/config/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.sparta_logistics.delivery.presentation.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Components components = new Components()
+        .addSecuritySchemes("X-User-Id",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Id"))
+        .addSecuritySchemes("X-User-Name",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Name"))
+        .addSecuritySchemes("X-User-Role",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Role"));
+    return new OpenAPI()
+        .components(components)
+        .addSecurityItem(new SecurityRequirement()
+            .addList("X-User-Id")
+            .addList("X-User-Name")
+            .addList("X-User-Role"))
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("Spring Boot REST API Specifications")
+        .description("product api")
+        .version("1.0.0");
+  }
+
+}

--- a/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/controller/DeliveryController.java
+++ b/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/controller/DeliveryController.java
@@ -6,6 +6,7 @@ import com.sparta_logistics.delivery.presentation.dto.auth.RequestUserDetails;
 import com.sparta_logistics.delivery.presentation.dto.request.delivery.DeliveryCreateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RefreshScope
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/deliveries")

--- a/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/controller/DeliveryManagerController.java
+++ b/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/controller/DeliveryManagerController.java
@@ -8,6 +8,7 @@ import com.sparta_logistics.delivery.presentation.dto.request.deliverymanager.De
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RefreshScope
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/delivery-managers")

--- a/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/filter/JwtAuthenticationFilter.java
+++ b/com.sparta_logistics.delivery/src/main/java/com/sparta_logistics/delivery/presentation/filter/JwtAuthenticationFilter.java
@@ -18,27 +18,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    //Mock 데이터 생성
-    String userId = request.getHeader("X-User-Id");
-    String userName = request.getHeader("X-User-Name");
-    String role = request.getHeader("X-User-Role");
 
-    if (userId == null || userName == null || role == null) {
-      throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+    if (request.getRequestURI().startsWith("/api/v1/deliveries/v3/api-docs") ||
+        request.getRequestURI().startsWith("/api/v1/deliveries/swagger")){
+      filterChain.doFilter(request, response);
+    } else {
+      //Mock 데이터 생성
+      String userId = request.getHeader("X-User-Id");
+      String userName = request.getHeader("X-User-Name");
+      String role = request.getHeader("X-User-Role");
+
+      if (userId == null || userName == null || role == null) {
+        throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+      }
+
+      //Mock 유저 생성
+      RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role);
+
+      // Authentication 객체 생성
+      UsernamePasswordAuthenticationToken authentication =
+          new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities());
+
+      // SecurityContext에 인증 정보 설정
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      // 필터 체인 진행
+      filterChain.doFilter(request, response);
     }
-
-    //Mock 유저 생성
-    RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role);
-
-    // Authentication 객체 생성
-    UsernamePasswordAuthenticationToken authentication =
-        new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities());
-
-    // SecurityContext에 인증 정보 설정
-    SecurityContextHolder.getContext().setAuthentication(authentication);
-
-    // 필터 체인 진행
-    filterChain.doFilter(request, response);
-
   }
 }

--- a/com.sparta_logistics.hub/build.gradle
+++ b/com.sparta_logistics.hub/build.gradle
@@ -29,6 +29,10 @@ ext {
 }
 
 dependencies {
+	//config-client
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	//querydsl
 	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/com.sparta_logistics.hub/build.gradle
+++ b/com.sparta_logistics.hub/build.gradle
@@ -29,6 +29,8 @@ ext {
 }
 
 dependencies {
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	//config-client
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/com.sparta_logistics.hub/src/main/java/com/sparta_logistics/hub/infrastructure/configuration/SwaggerConfig.java
+++ b/com.sparta_logistics.hub/src/main/java/com/sparta_logistics/hub/infrastructure/configuration/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.sparta_logistics.hub.infrastructure.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Components components = new Components()
+        .addSecuritySchemes("X-User-Id",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Id"))
+        .addSecuritySchemes("X-User-Name",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Name"))
+        .addSecuritySchemes("X-User-Role",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Role"));
+    return new OpenAPI()
+        .components(components)
+        .addSecurityItem(new SecurityRequirement()
+            .addList("X-User-Id")
+            .addList("X-User-Name")
+            .addList("X-User-Role"))
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("Spring Boot REST API Specifications")
+        .description("product api")
+        .version("1.0.0");
+  }
+
+}

--- a/com.sparta_logistics.hub/src/main/java/com/sparta_logistics/hub/presentation/controller/HubController.java
+++ b/com.sparta_logistics.hub/src/main/java/com/sparta_logistics/hub/presentation/controller/HubController.java
@@ -19,6 +19,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RefreshScope
 @RestController
 @RequestMapping("/api/v1/hubs")
 @RequiredArgsConstructor

--- a/com.sparta_logistics.order/build.gradle
+++ b/com.sparta_logistics.order/build.gradle
@@ -28,6 +28,10 @@ ext {
 }
 
 dependencies {
+	//config-client
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'

--- a/com.sparta_logistics.order/build.gradle
+++ b/com.sparta_logistics.order/build.gradle
@@ -31,12 +31,12 @@ dependencies {
 	//config-client
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'

--- a/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/config/SecurityConfig.java
+++ b/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(authorize -> authorize
             .anyRequest().permitAll()
         )
-        .httpBasic(Customizer.withDefaults());
+        .httpBasic(Customizer.withDefaults())
+        .httpBasic(AbstractHttpConfigurer::disable);
 
     return http.build();
   }

--- a/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/config/SwaggerConfig.java
+++ b/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/config/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.sparta_logistics.order.presentation.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Components components = new Components()
+        .addSecuritySchemes("X-User-Id",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Id"))
+        .addSecuritySchemes("X-User-Name",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Name"))
+        .addSecuritySchemes("X-User-Role",
+            new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("X-User-Role"));
+    return new OpenAPI()
+        .components(components)
+        .addSecurityItem(new SecurityRequirement()
+            .addList("X-User-Id")
+            .addList("X-User-Name")
+            .addList("X-User-Role"))
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("Spring Boot REST API Specifications")
+        .description("product api")
+        .version("1.0.0");
+  }
+
+}

--- a/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/controller/OrderController.java
+++ b/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/controller/OrderController.java
@@ -13,12 +13,14 @@ import jakarta.validation.Valid;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@RefreshScope
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/orders")

--- a/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/filter/JwtAuthenticationFilter.java
+++ b/com.sparta_logistics.order/src/main/java/com/sparta_logistics/order/presentation/filter/JwtAuthenticationFilter.java
@@ -19,27 +19,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    //Mock 데이터 생성
-    String userId = request.getHeader("ID_HEADER");
-    String userName = request.getHeader("NAME_HEADER");
-    String role = request.getHeader("ROLE_HEADER");
-    String userSlackId = request.getHeader("SLACK_ID_HEADER");
-    if (userId == null || userName == null || role == null) {
-      throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+
+    if (request.getRequestURI().startsWith("/api/v1/orders/v3/api-docs") ||
+        request.getRequestURI().startsWith("/api/v1/orders/swagger")){
+      filterChain.doFilter(request, response);
+    } else {
+      //Mock 데이터 생성
+      String userId = request.getHeader("ID_HEADER");
+      String userName = request.getHeader("NAME_HEADER");
+      String role = request.getHeader("ROLE_HEADER");
+      String userSlackId = request.getHeader("SLACK_ID_HEADER");
+      if (userId == null || userName == null || role == null) {
+        throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
+      }
+
+      //Mock 유저 생성
+      RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role, userSlackId);
+
+      // Authentication 객체 생성
+      UsernamePasswordAuthenticationToken authentication =
+          new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities());
+
+      // SecurityContext에 인증 정보 설정
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      // 필터 체인 진행
+      filterChain.doFilter(request, response);
     }
-
-    //Mock 유저 생성
-    RequestUserDetails mockUserDetails = new RequestUserDetails(userId, userName, role, userSlackId);
-
-    // Authentication 객체 생성
-    UsernamePasswordAuthenticationToken authentication =
-        new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities());
-
-    // SecurityContext에 인증 정보 설정
-    SecurityContextHolder.getContext().setAuthentication(authentication);
-
-    // 필터 체인 진행
-    filterChain.doFilter(request, response);
-
   }
 }

--- a/com.sparta_logistics.order/src/main/resources/application.yml
+++ b/com.sparta_logistics.order/src/main/resources/application.yml
@@ -11,14 +11,6 @@ spring:
         enabled: true
         service-id: config-server
 
-# http://localhost:19097/actuator/refresh 사용을 위한 설정
-# 코드 내 @RefreshScope 적용 필요
-management:
-  endpoints:
-    web:
-      exposure:
-        include: refresh
-
 eureka:
   client:
     service-url:


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- reafactor/67/config -> develop
### 이슈
- resolved: #67 
### Description
- config server의 yml 파일은 각자 로컬에서 관리하고 커밋하지 않으려고 했다가 5개 파일에 같은 코드가 들어가서 업데이트를 한 번 하는 게 좋을 듯 해서 커밋 했습니다.
- 머지되고 나서 풀 받으시고 나면 yml 파일에서 db 설정 한 번씩 본인 로컬 설정으로 다시 해 주시면 감사하겠습니다.
- Hub, Company, Order, delivery 서비스 모두 config server에서 yml 파일을 가져오는 방식으로 변경했습니다.
- 필터에서 refresh/actuator 메서드를 블락하고 있어 동작하지 않습니다. 해결하지 못 했습니다.
- Hub, Company, Order, Delivey 도메인에 스웨거 적용 완료했습니다.
[http://localhost:{각](http://localhost:%7B%EA%B0%81/) 서비스 포트 번호}/api/v1/{도메인(복수)}/v3/api-docs 요청을 통해 각 서비스의 swagger ui를 확인할 수 있습니다.
Hub port : 19094
Company port : 19095
Order port : 19096
Delivery port : 19098
### To Reviewers
- 팀장님 방식대로 filter에 mock 객체를 생성하면 모든 요청의 authentication이 해당 객체의 것으로 변경되는 듯 해서, swagger 요청에 대해서만 필터를 통과시키는 식으로 구현해 봤습니다.